### PR TITLE
Revert to v0.3.1 of node-untappd

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/stephenyeargin/hubot-untappd-friends/issues"
   },
   "dependencies": {
-    "node-untappd": "~0.4.1",
+    "node-untappd": "~0.3.1",
     "moment": "^2.18.1"
   },
   "devDependencies": {


### PR DESCRIPTION
A refactoring went a bit awry upstream, but it continues to work with the old version. Some notes for whenever the update happens:

- `friendFeed` appears to have changed to `activityFeed` (maybe?)
- The auth tokens do not appear to be set up correctly (got errors for v4 of API of them not being sent along with the request)

Fixes #3