### PR TITLE
Badge formatting for Slack, add username to titles

### DIFF
--- a/test/untappd-friends-slack_test.coffee
+++ b/test/untappd-friends-slack_test.coffee
@@ -58,23 +58,95 @@ describe 'hubot-untappd-friends for slack', ->
             {
               "attachments": [
                 {
-                  "author_name": "an hour ago at 49 Çukurcuma"
-                  "color": "#7CD197"
-                  "fallback": "heath was drinking a Blonde Ale (Blonde Ale - 5%) by Gara Guzu Brewery at 49 Çukurcuma - an hour ago"
-                  "footer": "Earned the Beer Foodie (Level 44) badge and 2 more"
-                  "footer_icon": "https://untappd.akamaized.net/badges/bdg_BeerFoodie_sm.jpg"
-                  "thumb_url": "https://untappd.akamaized.net/site/beer_logos/beer-764911_07c43_sm.jpeg"
-                  "title": "heath was drinking a Blonde Ale by Gara Guzu Brewery"
+                  "author_name": "an hour ago at 49 Çukurcuma",
+                  "color": "#7CD197",
+                  "fallback": "heath (heathseals) was drinking a Blonde Ale (Blonde Ale - 5%) by Gara Guzu Brewery at 49 Çukurcuma - an hour ago",
+                  "footer": "Earned the Beer Foodie (Level 44) badge and 2 more",
+                  "footer_icon": "https://untappd.akamaized.net/badges/bdg_BeerFoodie_sm.jpg",
+                  "thumb_url": "https://untappd.akamaized.net/site/beer_logos/beer-764911_07c43_sm.jpeg",
+                  "title": "heath (heathseals) was drinking a Blonde Ale by Gara Guzu Brewery",
                   "title_link": "https://untappd.com/user/heathseals/checkin/578981788"
-                }
+                },
                 {
-                  "author_name": "8 hours ago at DERALIYE OTTOMAN CUISINE"
-                  "color": "#7CD197"
-                  "fallback": "heath was drinking a Efes Pilsen (Pilsner - Other - 5%) by Anadolu Efes at DERALIYE OTTOMAN CUISINE - 8 hours ago"
-                  "footer": "Earned the Beer Connoisseur (Level 8) badge"
-                  "footer_icon": "https://untappd.akamaized.net/badges/bdg_connoiseur_sm.jpg"
-                  "thumb_url": "https://untappd.akamaized.net/site/beer_logos/beer-EfesPilsener_17259.jpeg"
-                  "title": "heath was drinking a Efes Pilsen by Anadolu Efes"
+                  "author_name": "8 hours ago at DERALIYE OTTOMAN CUISINE",
+                  "color": "#7CD197",
+                  "fallback": "heath (heathseals) was drinking a Efes Pilsen (Pilsner - Other - 5%) by Anadolu Efes at DERALIYE OTTOMAN CUISINE - 8 hours ago",
+                  "footer": "Earned the Beer Connoisseur (Level 8) badge",
+                  "footer_icon": "https://untappd.akamaized.net/badges/bdg_connoiseur_sm.jpg",
+                  "thumb_url": "https://untappd.akamaized.net/site/beer_logos/beer-EfesPilsener_17259.jpeg",
+                  "title": "heath (heathseals) was drinking a Efes Pilsen by Anadolu Efes",
+                  "title_link": "https://untappd.com/user/heathseals/checkin/578869664"
+                }
+              ]
+            }
+          ]
+        ]
+        done()
+      catch err
+        done err
+      return
+    , 1000)
+
+  # hubot untappd badges
+  it 'responds with the latest badge activity from your friends', (done) ->
+    nock('https://api.untappd.com')
+      .get('/v4/checkin/recent')
+      .query(
+        limit: 2,
+        client_id: 'foobar1',
+        client_secret: 'foobar2',
+        access_token: 'foobar3',
+      )
+      .replyWithFile(200, __dirname + '/fixtures/checkin-recent.json')
+
+    selfRoom = @room
+    selfRoom.user.say('alice', '@hubot untappd badges')
+    setTimeout(() ->
+      try
+        expect(selfRoom.messages).to.eql [
+          ['alice', '@hubot untappd badges']
+          [
+            'hubot',
+            {
+              "attachments": [
+                {
+                  "author_name": "an hour ago at 49 Çukurcuma",
+                  "color": "#7CD197",
+                  "fallback": "heath (heathseals) earned the Beer Foodie (Level 44) Badge after drinking a Blonde Ale at 49 Çukurcuma - an hour ago",
+                  "footer": "Blonde Ale",
+                  "footer_icon": "https://untappd.akamaized.net/site/beer_logos/beer-764911_07c43_sm.jpeg",
+                  "thumb_url": "https://untappd.akamaized.net/badges/bdg_BeerFoodie_sm.jpg",
+                  "title": "heath (heathseals) earned the Beer Foodie (Level 44) Badge",
+                  "title_link": "https://untappd.com/user/heathseals/checkin/578981788"
+                },
+                {
+                  "author_name": "an hour ago at 49 Çukurcuma",
+                  "color": "#7CD197",
+                  "fallback": "heath (heathseals) earned the 99 Bottles (Level 38) Badge after drinking a Blonde Ale at 49 Çukurcuma - an hour ago",
+                  "footer": "Blonde Ale",
+                  "footer_icon": "https://untappd.akamaized.net/site/beer_logos/beer-764911_07c43_sm.jpeg",
+                  "thumb_url": "https://untappd.akamaized.net/badges/bdg_99Bottles_sm.jpg",
+                  "title": "heath (heathseals) earned the 99 Bottles (Level 38) Badge",
+                  "title_link": "https://untappd.com/user/heathseals/checkin/578981788"
+                },
+                {
+                  "author_name": "an hour ago at 49 Çukurcuma",
+                  "color": "#7CD197",
+                  "fallback": "heath (heathseals) earned the Pizza & Brew (Level 4) Badge after drinking a Blonde Ale at 49 Çukurcuma - an hour ago",
+                  "footer": "Blonde Ale",
+                  "footer_icon": "https://untappd.akamaized.net/site/beer_logos/beer-764911_07c43_sm.jpeg",
+                  "thumb_url": "https://untappd.akamaized.net/badges/bdg_PizzaAndBrew_sm.jpg",
+                  "title": "heath (heathseals) earned the Pizza & Brew (Level 4) Badge",
+                  "title_link": "https://untappd.com/user/heathseals/checkin/578981788"
+                },
+                {
+                  "author_name": "8 hours ago at DERALIYE OTTOMAN CUISINE",
+                  "color": "#7CD197",
+                  "fallback": "heath (heathseals) earned the Beer Connoisseur (Level 8) Badge after drinking a Efes Pilsen at DERALIYE OTTOMAN CUISINE - 8 hours ago",
+                  "footer": "Efes Pilsen",
+                  "footer_icon": "https://untappd.akamaized.net/site/beer_logos/beer-EfesPilsener_17259.jpeg",
+                  "thumb_url": "https://untappd.akamaized.net/badges/bdg_connoiseur_sm.jpg",
+                  "title": "heath (heathseals) earned the Beer Connoisseur (Level 8) Badge",
                   "title_link": "https://untappd.com/user/heathseals/checkin/578869664"
                 }
               ]

--- a/test/untappd-friends_test.coffee
+++ b/test/untappd-friends_test.coffee
@@ -52,8 +52,8 @@ describe 'hubot-untappd-friends', ->
       try
         expect(selfRoom.messages).to.eql [
           ['alice', '@hubot untappd']
-          ['hubot', 'heath was drinking a Blonde Ale (Blonde Ale - 5%) by Gara Guzu Brewery at 49 Çukurcuma - an hour ago']
-          ['hubot', 'heath was drinking a Efes Pilsen (Pilsner - Other - 5%) by Anadolu Efes at DERALIYE OTTOMAN CUISINE - 8 hours ago']
+          ['hubot', 'heath (heathseals) was drinking a Blonde Ale (Blonde Ale - 5%) by Gara Guzu Brewery at 49 Çukurcuma - an hour ago']
+          ['hubot', 'heath (heathseals) was drinking a Efes Pilsen (Pilsner - Other - 5%) by Anadolu Efes at DERALIYE OTTOMAN CUISINE - 8 hours ago']
         ]
         done()
       catch err
@@ -79,10 +79,10 @@ describe 'hubot-untappd-friends', ->
       try
         expect(selfRoom.messages).to.eql [
           ['alice', '@hubot untappd badges']
-          ['hubot', 'heathseals earned the Beer Foodie (Level 44) Badge after drinking a Blonde Ale at 49 Çukurcuma - an hour ago']
-          ['hubot', 'heathseals earned the 99 Bottles (Level 38) Badge after drinking a Blonde Ale at 49 Çukurcuma - an hour ago']
-          ['hubot', 'heathseals earned the Pizza & Brew (Level 4) Badge after drinking a Blonde Ale at 49 Çukurcuma - an hour ago']
-          ['hubot', 'heathseals earned the Beer Connoisseur (Level 8) Badge after drinking a Efes Pilsen at DERALIYE OTTOMAN CUISINE - 8 hours ago']
+          ['hubot', 'heath (heathseals) earned the Beer Foodie (Level 44) Badge after drinking a Blonde Ale at 49 Çukurcuma - an hour ago']
+          ['hubot', 'heath (heathseals) earned the 99 Bottles (Level 38) Badge after drinking a Blonde Ale at 49 Çukurcuma - an hour ago']
+          ['hubot', 'heath (heathseals) earned the Pizza & Brew (Level 4) Badge after drinking a Blonde Ale at 49 Çukurcuma - an hour ago']
+          ['hubot', 'heath (heathseals) earned the Beer Connoisseur (Level 8) Badge after drinking a Efes Pilsen at DERALIYE OTTOMAN CUISINE - 8 hours ago']
         ]
         done()
       catch err


### PR DESCRIPTION
- Adds Slack-specific formatting for the `hubot untappd badges` command to continue previous enhancements (#10)
- Adds the username back to the various messages for disambiguation (#12)

Fixes #12

---

### Slack

![screen shot 2018-04-02 at 10 12 26 am](https://user-images.githubusercontent.com/80459/38201646-999e77a4-365e-11e8-9c3a-ea9c11b4d84c.png)

![screen shot 2018-04-02 at 10 12 53 am](https://user-images.githubusercontent.com/80459/38201649-9c1c339a-365e-11e8-8f71-bfcb02ecd813.png)



### IRC

```
alice> @hubot untappd
hubot> heath (heathseals) was drinking a Blonde Ale (Blonde Ale - 5%) by Gara Guzu Brewery at 49 Çukurcuma - an hour ago
hubot> heath (heathseals) was drinking a Efes Pilsen (Pilsner - Other - 5%) by Anadolu Efes at DERALIYE OTTOMAN CUISINE - 8 hours ago
```


```
alice> @hubot untappd badges
hubot> heath (heathseals) earned the Beer Foodie (Level 44) Badge after drinking a Blonde Ale at 49 Çukurcuma - an hour ago
hubot> heath (heathseals) earned the 99 Bottles (Level 38) Badge after drinking a Blonde Ale at 49 Çukurcuma - an hour ago
hubot> heath (heathseals) earned the Pizza & Brew (Level 4) Badge after drinking a Blonde Ale at 49 Çukurcuma - an hour ago
hubot> heath (heathseals) earned the Beer Connoisseur (Level 8) Badge after drinking a Efes Pilsen at DERALIYE OTTOMAN CUISINE - 8 hours ago
```